### PR TITLE
Update docker_ubuntu.md

### DIFF
--- a/docs/soft/Lichee/zh/Zero-Doc/Start/docker_ubuntu.md
+++ b/docs/soft/Lichee/zh/Zero-Doc/Start/docker_ubuntu.md
@@ -6,6 +6,5 @@ title: 基础ubuntu系统配置
 
 ```
 sudo apt-get update
-sudo apt-get install iputils-ping vim git wget xz-utils bzip2 gcc device-tree-compiler python time make
-wget https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/gcc-linaro-7.1.1-2017.08-x86_64_arm-linux-gnueabihf.tar.xz
+sudo apt-get install iputils-ping vim git wget xz-utils bzip2 gcc device-tree-compiler python time make gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf 
 ```


### PR DESCRIPTION
`https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/gcc-linaro-7.1.1-2017.08-x86_64_arm-linux-gnueabihf.tar.xz` 404 not found, chage to apt to install package