### PR TITLE
Make GitHub Actions can only run in the original repository.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # Only run job for specific repository
+    if: github.repository == 'sipeed/sipeed_wiki'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/publish_upload_all.yml
+++ b/.github/workflows/publish_upload_all.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # Only run job for specific repository
+    if: github.repository == 'sipeed/sipeed_wiki'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/sync_gitee.yml
+++ b/.github/workflows/sync_gitee.yml
@@ -22,6 +22,8 @@ jobs:
   # This workflow contains a single job called "build"
   sync_gitee:
     name: sync repo to gitee
+    # Only run job for specific repository
+    if: github.repository == 'sipeed/sipeed_wiki'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# 配置 GitHub Actions 相关 CI 为只能在原仓库执行

具体 yml 语法示例详见 [Github 官方文档](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository) 。

这一 PR 主要是为了方便和预防贡献者由于之前贡献过代码但后来又想添加东西时先执行同步仓库（Sync Fork）导致的 Actions 在贡献者仓库触发且运行失败的情况发生。（事实上就是我目前遇到的问题，Sync Fork 同步一下自己仓库下的 Actions 跑起来了，然后就会邮件告知运行失败啥的）