### PR TITLE
en/sidebar: Fix typo

### DIFF
--- a/docs/hardware/en/sidebar.yaml
+++ b/docs/hardware/en/sidebar.yaml
@@ -283,7 +283,7 @@ items:
     items:
     -   label: SP-MOD Peripheral modules
         items:
-        -   label: Adapter borad
+        -   label: Adapter board
             items:
             -   label: SP-Extender
                 file: modules_spmod/spmod_extender.md


### PR DESCRIPTION
![](https://media.tenor.com/L0pT08DVkjAAAAAC/borat-smiling-borat.gif)

(gif from the movie borat, bcs the typo is borad and people probably won't get a doctor who reference)