### PR TITLE
Avoid copying spaces from openbmc password

### DIFF
--- a/docs/hardware/zh/lichee/th1520/lc4a/lc4a.md
+++ b/docs/hardware/zh/lichee/th1520/lc4a/lc4a.md
@@ -201,7 +201,7 @@ bmaptool copy obmc-phosphor-image-licheepi-rv.wic.gz /dev/YOUR_SDCARD
 
 默认用户名: `root`
 
-默认密码:   `0penBmc`
+默认密码: `0penBmc`
 
 0 是零，不是 O
 


### PR DESCRIPTION
Leaving multiple spaces after the colon makes at least Firefox copy an additional space in front of the password and fail the login on paste.

Let's avoid this behavior to make our lives easier :)