### PR TITLE
使用maixduino时，在例程2，缺少lcd.init()，导致图片无法显示

### DIFF
--- a/docs/soft/maixpy/zh/api_reference/machine_vision/lcd.md
+++ b/docs/soft/maixpy/zh/api_reference/machine_vision/lcd.md
@@ -190,7 +190,8 @@ lcd.draw_string(100, 100, "hello maixpy", lcd.RED, lcd.BLACK)
 import lcd
 import image
 
-img = image.Image("/sd/pic.bmp")
+lcd.init()
+img = image.Image("/sd/pic.bmp")#320*240
 lcd.display(img)
 ```
 


### PR DESCRIPTION
同时增加了自带套件LCD屏幕的推荐像素