### PR TITLE
Update Specifications / Comparison with PiKVM v4

### DIFF
--- a/docs/hardware/en/kvm/NanoKVM/introduction.md
+++ b/docs/hardware/en/kvm/NanoKVM/introduction.md
@@ -39,29 +39,31 @@ To meet different user needs, NanoKVM is available in two versions:
 
 ## Specifications
 
-| Product | NanoKVM (Lite) | NanoKVM (Full) | PiKVM V4 |
-| --- | --- | --- | --- |
-| Computing Unit | LicheeRV Nano (RISCV) | LicheeRV Nano (RISCV) | CM4 (ARM) |
-| Resolution | 1080P @ 60fps | 1080P @ 60fps | 1080P @ 60fps |
-| Video Encoding | MJPEG, H264 (WIP) | MJPEG, H264 (WIP) | MJPEG, H264 |
-| Video Latency | 90-230ms | 90-230ms | 100-230ms |
-| UEFI/BIOS | ✓ | ✓ | ✓ |
-| Emulated USB Keyboard/Mouse | ✓ | ✓ | ✓ |
-| Emulated USB Storage | ✓ | ✓ | ✓ |
-| IPMI | ✓ | ✓ | ✓ |
-| Wake-on-LAN | ✓ | ✓ | ✓ |
-| Tailscale | ✓ | ✓ | ✓ |
-| WebSSH | ✓ | ✓ | ✓ |
-| Custom Scripts | ✓ | ✓ | - |
-| ATX Power Control | None, user-configurable | USB interface IO control board | RJ45 interface IO control board |
-| OLED Display | None, user-expandable | 128x64 0.96" white | 128x32 0.91" white |
-| Serial Terminal | 2 channels | 2 channels | - |
-| TF Card | None, user-provided | Included, ready to use | Included |
-| Expansion Accessories | None | WiFi or PoE | WiFi/LTE |
-| Power Consumption | 0.2A@5V | 0.2A@5V | Peak 2.6A@5V |
-| Power Input | Powered by PC USB | Powered by PC USB <br> Supports auxiliary power | Requires DC 5V 3A |
-| Cooling | Silent, fanless | Silent, fanless | Requires active fan cooling |
-| Dimensions | 23x37x15mm <br> ~1/30 PiKVM V4 size | 40x36x36mm <br> ~1/7 PiKVM V4 size | 120x68x44mm |
+| Product                     | NanoKVM (Lite)                      | NanoKVM (Full)                                  | PiKVM V4                        |
+| --------------------------- | ----------------------------------- | ----------------------------------------------- | ------------------------------- |
+| Computing Unit              | LicheeRV Nano (RISCV)               | LicheeRV Nano (RISCV)                           | CM4 (ARM)                       |
+| Resolution                  | 1080P @ 60fps                       | 1080P @ 60fps                                   | 1080P, 1200P @ 60fps            |
+| Video Encoding              | MJPEG, H264 (WIP)                   | MJPEG, H264 (WIP)                               | MJPEG, H264                     |
+| Video Latency               | 90-230ms                            | 90-230ms                                        | 100-230ms                       |
+| UEFI/BIOS                   | ✓                                   | ✓                                               | ✓                               |
+| Emulated USB Keyboard/Mouse | ✓                                   | ✓                                               | ✓                               |
+| Emulated USB Storage        | ✓                                   | ✓                                               | ✓                               |
+| IPMI                        | ✓                                   | ✓                                               | ✓                               |
+| Wake-on-LAN                 | ✓                                   | ✓                                               | ✓                               |
+| Tailscale                   | ✓                                   | ✓                                               | ✓                               |
+| WebSSH                      | ✓                                   | ✓                                               | ✓                               |
+| Custom Scripts              | ✓                                   | ✓                                               | ✓                               |
+| RTC                         | -                                   | -                                               | ✓                               |
+| Ethernet                    | 10/100MbE                           | 10/100MbE                                       | 10/100/1GbE                     |
+| ATX Power Control           | None, user-configurable             | USB interface IO control board                  | RJ45 interface IO control board |
+| OLED Display                | None, user-expandable               | 128x64 0.96" white                              | 128x32 0.91" white              |
+| Serial Terminal             | 2 channels                          | 2 channels                                      | 1 channel                       |
+| TF Card                     | None, user-provided                 | Included, ready to use                          | Included                        |
+| Expansion Accessories       | None                                | WiFi or PoE                                     | WiFi/LTE, PoE                   |
+| Power Consumption           | 0.2A@5V                             | 0.2A@5V                                         | Peak 2.6A@5V                    |
+| Power Input                 | Powered by PC USB                   | Powered by PC USB <br> Supports auxiliary power | Requires DC 5V 3A               |
+| Cooling                     | Silent, fanless                     | Silent, fanless                                 | Requires active fan cooling     |
+| Dimensions                  | 23x37x15mm <br> ~1/30 PiKVM V4 size | 40x36x36mm <br> ~1/7 PiKVM V4 size              | 120x68x44mm                     |
 
 ## NanoKVM Hardware and Software Resources
 


### PR DESCRIPTION
- Update specifications table
	- Add row for NIC/ethernet capabilties (this is important as 100MbE NICs will not work on most 1/2.5GbE, 1/5GbE, 1/10GbE networks/switches as I found out in https://github.com/sipeed/NanoKVM/issues/7#issuecomment-2299752021)
	- Correct PiKVM v4 specs (supports 1200P, PoE, Serial Term, RTC)

Note I'm not downplaying how awesome the NanoKVM is, it's a very neat device, just want to make sure we're being true to the specs.

Sources:

- https://pikvm.org
- https://docs.pikvm.org/faq/
- https://github.com/sipeed/NanoKVM/issues/7#issuecomment-2299752021