### PR TITLE
Fix English quick_start.md image update link

### DIFF
--- a/docs/hardware/en/kvm/NanoKVM/quick_start.md
+++ b/docs/hardware/en/kvm/NanoKVM/quick_start.md
@@ -84,7 +84,7 @@ The Full version comes with a pre-flashed image and can skip this step.
 
 Images are updated periodically. It is recommended to update to the latest version for the best experience.
 
-For detailed instructions, please refer to [Flashing Image](https://wiki.sipeed.com/hardware/zh/kvm/NanoKVM/system/flashing.html).
+For detailed instructions, please refer to [Flashing Image](https://wiki.sipeed.com/hardware/en/kvm/NanoKVM/system/flashing.html).
 
 ### Update Application
 


### PR DESCRIPTION
Fixed update image link in english quick_start guide. It was pointing to the `zh` path, not the `en` path.