### PR TITLE
Add a example core to tang nano 9k

### DIFF
--- a/docs/hardware/en/tang/Tang-Nano-9K/examples/neorv32.md
+++ b/docs/hardware/en/tang/Tang-Nano-9K/examples/neorv32.md
@@ -1,0 +1,27 @@
+# NeoRV32 on nano 9K
+
+## Preface
+
+NeoRV32 is a powerful RISCV5 core
+
+![](https://github.com/stnolting/neorv32/raw/main/docs/figures/neorv32_processor.png)
+
+There is an example neorv32 project using the built in 72kb of user flash as instruction memory and with GPIO and JTAG enabled for debugging: [Tang Nano 9K github repository](https://github.com/jimmyw/tang_nano_9k_neorv32).
+
+## Environment
+
+- [Gowin IDE](./../../common-doc/install-the-ide.md)
+- [GCC Toolchain](https://stnolting.github.io/neorv32/ug/#_software_toolchain_setup)
+
+## Steps
+
+### Program FPGA
+
+- Clone example repo `git clone git@github.com/jimmyw/tang_nano_9k_neorv32`
+- Open tang_nano_9k project by `tang_nano_9k.gprj` file in `src` directory
+- Right-click Place&Route which is in Process interface and choose Clean&Rerun All
+- Compile the userspace code in `hello_world` using `make all`
+- Download the generated .fs file to the Embedded Flash of Nano 9K using `openFPGALoader -f impl/pnr/tang_nano_9k.fs  --user-flash hello_world/neorv32_raw_exe.bin`
+
+You can at a later state update the user space flash directly from the bootloader using `python uart_upload.py /dev/ttyUSB0 neorv32_exe.bin`
+

--- a/docs/hardware/en/tang/common-doc/examples.md
+++ b/docs/hardware/en/tang/common-doc/examples.md
@@ -62,6 +62,7 @@ Github: https://github.com/sipeed/TangNano-9K-example
 - [FPGA drives 1.14-inch SPI screen](./../Tang-Nano-9K/examples/spi_lcd.md)
 - HDMI display : [Examples of PicoRV](./../Tang-Nano-9K/examples/picorv.md)
 - Litex on Tang Nano 9K : https://github.com/litex-hub/litex-boards
+- Powerful NeoRV32 riscv core on 9K: [NEORV32](./../Tang-Nano-9K/examples/neorv32.md)
 
 Partner tutorials:
 <a href="https://learn.lushaylabs.com/tang-nano-series/"><img src="./../../../zh/tang/common-doc/assets/lushaylab_logo.png" alt="lushaylab_logo" width="35%"></a>


### PR DESCRIPTION
I have been working of implementing the powerful NanoRV32 core on my Tang 9k, but not until i wrote a userflash driver for the 72kb userspace flash that exists in the 9k it got powerful enough to run my Zephyr os projects, even dual core.

In my example i also added JTAG support, that is very convenient when your project grows, and complexity increases.

I like to share this project, so other may build on it, so i documented on your wiki how to get started.