### PR TITLE
添加导出 onnx 模型时的一个参数

### DIFF
--- a/docs/hardware/zh/lichee/th1520/lpi4a/8_application.md
+++ b/docs/hardware/zh/lichee/th1520/lpi4a/8_application.md
@@ -415,7 +415,7 @@ n02124075 Egyptian cat
 git clone https://github.com/ultralytics/yolov5.git
 cd yolov5
 pip3 install ultralytics
-python3 export.py --weights yolov5n.pt --include onnx
+python3 export.py --weights yolov5n.pt --include onnx --imgsz 384 640
 ```
 
 #### 编译


### PR DESCRIPTION
后面 hbb 编译时指定了 `--input-shape "1 3 384 640"` ，如果在导出 onnx 模型时没有指定 `--imgsz 384 640` ，会导致 hbb 编译失败。