### PR TITLE
Change SDRAM to PSRAM

### DIFF
--- a/docs/hardware/en/tang/Tang-Nano-9K/Nano-9K.md
+++ b/docs/hardware/en/tang/Tang-Nano-9K/Nano-9K.md
@@ -35,7 +35,7 @@ Indepth specifications of the tang nano 9k.
 | Block SRAM BSRAM(bits) | 468K                                                                                                                                                                     |
 | Number of B-SRAM       | 26                                                                                                                                                                       |
 | User flash(bits)       | 608K                                                                                                                                                                     |
-| SDR SDRAM(bits)        | 64M                                                                                                                                                                      |
+| PSRAM(bits)            | 64M                                                                                                                                                                      |
 | 18 x 18 Multiplier     | 20                                                                                                                                                                       |
 | SPI FLASH              | 32M-bit                                                                                                                                                                  |
 | Number of PLL          | 2                                                                                                                                                                        |


### PR DESCRIPTION
The FPGA used by Tang-Nano-9K is GW1NR-LV9QN88P, which does not have SDRAM, but PSRAM instead. This change reduce confusion when choosing which memory IP to use.

The [official datasheet](https://cdn.gowinsemi.com.cn/DS117E.pdf) clearly states that all devices with QN88P packaging uses PSRAM for built-in RAM. (In fact, all devices with P in packaging code uses PSRAM) Additionally, the Gowin FPGA designer also includes GW1NR-LV9QN88P in its "PSRAM Memory Interface HS" section of IP generator.

<img width="506" height="306" alt="image" src="https://github.com/user-attachments/assets/5f9a05c2-d7d2-4235-94d2-41284a4904b9" />

The error has created [some confusion](https://www.reddit.com/r/FPGA/comments/1bvsdio/tang_nano_9k_memory_clarification/) among users when choosing which IP to use for RAM in Tang-Nano-9K.

This change has been done in the [Chinese version](https://wiki.sipeed.com/hardware/zh/tang/Tang-Nano-9K/Nano-9K.html) of the document, but not the [English one](https://wiki.sipeed.com/hardware/en/tang/Tang-Nano-9K/Nano-9K.html).