### PR TITLE
Fix target of link

### DIFF
--- a/docs/hardware/en/logic_analyzer/slogic16u3/Introduction.md
+++ b/docs/hardware/en/logic_analyzer/slogic16u3/Introduction.md
@@ -97,4 +97,4 @@ chmod +x Pulseview.appimage
 - GitHub (libsigrok slogic-dev): https://github.com/sipeed/libsigrok/tree/slogic-dev
 - Sipeed GitHub: https://github.com/sipeed
 - GitHub (SLogic16U3 Tools): https://github.com/sipeed/slogic16u3-tools
-- Community (Discord): [discord.gg/V4sAZ9XWpN](discord.gg/V4sAZ9XWpN)
+- Community (Discord): [discord.gg/V4sAZ9XWpN](https://discord.gg/V4sAZ9XWpN)

--- a/docs/hardware/zh/logic_analyzer/slogic16u3/Introduction.md
+++ b/docs/hardware/zh/logic_analyzer/slogic16u3/Introduction.md
@@ -99,4 +99,4 @@ chmod +x Pulseview.appimage
 - GitHub（libsigrok slogic-dev）：https://github.com/sipeed/libsigrok/tree/slogic-dev
 - Sipeed GitHub: https://github.com/sipeed
 - GitHub（SLogic16U3 Tools）：https://github.com/sipeed/slogic16u3-tools
-- 社区（Discord）：[discord.gg/V4sAZ9XWpN](discord.gg/V4sAZ9XWpN)
+- 社区（Discord）：[discord.gg/V4sAZ9XWpN](https://discord.gg/V4sAZ9XWpN)


### PR DESCRIPTION
Leaving the link without a "https://" prefix forces wiki to think of this as a relative path rather than an absolute path.