### PR TITLE
fix(nanokvm-pro): correct knob position from left to right (zh + en)

### DIFF
--- a/docs/hardware/en/kvm/NanoKVM_Pro/introduction.md
+++ b/docs/hardware/en/kvm/NanoKVM_Pro/introduction.md
@@ -17,7 +17,7 @@ To meet different user needs, NanoKVM Pro offers two forms: NanoKVM-Desk and Nan
 
 ![](./../../../assets/NanoKVM/pro/introduce/combine.png)
 
-NanoKVM-Desk is the desktop version of NanoKVM Pro, featuring an anodized matte metal shell. The front panel has a 1.47-inch touchscreen that displays core KVM information and allows for easy hardware function settings or can be used as a mini secondary screen, providing a more tactile user experience with the left-side infinite knob.
+NanoKVM-Desk is the desktop version of NanoKVM Pro, featuring an anodized matte metal shell. The front panel has a 1.47-inch touchscreen that displays core KVM information and allows for easy hardware function settings or can be used as a mini secondary screen, providing a more tactile user experience with the right-side infinite knob.
 
 NanoKVM-ATX is the internal version of NanoKVM Pro, equipped with half-height/full-height brackets for installation inside a case. It allows for easier installation for host users with built-in USB cables and power control interfaces. Remote control can be achieved via external HDMI, network, and USB connections.
 

--- a/docs/hardware/zh/kvm/NanoKVM_Pro/introduction.md
+++ b/docs/hardware/zh/kvm/NanoKVM_Pro/introduction.md
@@ -17,7 +17,7 @@ NanoKVM Pro 是 NanoKVM 的延续，作为 IP-KVM 产品继承了 NanoKVM 系列
 
 ![](./../../../assets/NanoKVM/pro/introduce/combine.png)
 
-NanoKVM-Desk 意为桌面版NanoKVM Pro，主体采用阳极氧化的磨砂金属外壳，前面板使用1.47寸触摸屏显示KVM核心信息，并且可以方便设置硬件功能，或作为mini副屏使用，搭配左侧无极旋钮获得更有质感的使用体验。
+NanoKVM-Desk 意为桌面版NanoKVM Pro，主体采用阳极氧化的磨砂金属外壳，前面板使用1.47寸触摸屏显示KVM核心信息，并且可以方便设置硬件功能，或作为mini副屏使用，搭配右侧无极旋钮获得更有质感的使用体验。
 
 NanoKVM-ATX 是NanoKVM Pro的机箱内版本，标配半高/全高挡板可安装在机箱内部，由于可以内置的USB线缆[3]和电源控制接口更方便主机用户安装。通过外部连接HDMI接口、网线和USB即可实现远程控制。
 


### PR DESCRIPTION
## 勘误 / Errata

The NanoKVM-Desk introduction incorrectly described the infinite knob as being on the **left** side. Based on the product photo, the knob is physically located on the **right** side of the front panel.

### Changes

- docs/hardware/zh/kvm/NanoKVM_Pro/introduction.md: 左侧无极旋钮 → 右侧无极旋钮
- docs/hardware/en/kvm/NanoKVM_Pro/introduction.md: left-side infinite knob → right-side infinite knob